### PR TITLE
lib: Use thread instead nest_asyncio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 casbin>=0.8.1
 SQLAlchemy>=1.2.18
 databases>=0.2.6
-nest-asyncio==1.5.1


### PR DESCRIPTION
Use thread to run nested event loop, since nest_asyncio patch doesn't work on uvloop.