### PR TITLE
Fix remove_filtered_policy bug

### DIFF
--- a/casbin_databases_adapter/adapter.py
+++ b/casbin_databases_adapter/adapter.py
@@ -71,7 +71,7 @@ class DatabasesAdapter(persist.Adapter):
             return False
         for i, value in enumerate(field_values):
             if len(value) > 0:
-                query = query.where(self.table.columns[f"v{field_index+1}"] == value)
+                query = query.where(self.table.columns[f"v{field_index+i}"] == value)
         result = await self.db.execute(query)
         return True if result else False
 


### PR DESCRIPTION
The existing remove_filtered_policy() function failed to properly remove policy rules due to a typo (`1` instead of `i`). This PR fixes that.